### PR TITLE
Add emoji mosaic camera view

### DIFF
--- a/EmojiCam.xcodeproj/project.pbxproj
+++ b/EmojiCam.xcodeproj/project.pbxproj
@@ -398,13 +398,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 84TRSZD4QB;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_KEY_NSCameraUsageDescription = "This app needs camera access to build an emoji mosaic.";
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -429,13 +430,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 84TRSZD4QB;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_KEY_NSCameraUsageDescription = "This app needs camera access to build an emoji mosaic.";
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/EmojiCam/CameraEmojiViewModel.swift
+++ b/EmojiCam/CameraEmojiViewModel.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import AVFoundation
+import CoreImage
+import CoreGraphics
+
+class CameraEmojiViewModel: NSObject, ObservableObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+    @Published var emojiGrid: [String]
+    let columns: Int
+    let rows: Int
+
+    private let session = AVCaptureSession()
+    private let context = CIContext()
+    private let queue = DispatchQueue(label: "emoji.camera.queue")
+
+    override init() {
+        self.columns = 40
+        self.rows = 40
+        self.emojiGrid = Array(repeating: "⬛️", count: columns * rows)
+        super.init()
+    }
+
+    func startSession() {
+        AVCaptureDevice.requestAccess(for: .video) { granted in
+            if granted {
+                self.setupSession()
+                self.session.startRunning()
+            }
+        }
+    }
+
+    func stopSession() {
+        session.stopRunning()
+    }
+
+    private func setupSession() {
+        session.beginConfiguration()
+        session.sessionPreset = .low
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front),
+              let input = try? AVCaptureDeviceInput(device: device),
+              session.canAddInput(input) else { return }
+        session.addInput(input)
+
+        let output = AVCaptureVideoDataOutput()
+        output.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        output.setSampleBufferDelegate(self, queue: queue)
+        guard session.canAddOutput(output) else { return }
+        session.addOutput(output)
+        output.connection(with: .video)?.videoOrientation = .portrait
+        session.commitConfiguration()
+    }
+
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        process(pixelBuffer: pixelBuffer)
+    }
+
+    private func process(pixelBuffer: CVPixelBuffer) {
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return }
+        guard let scaled = cgImage.scaled(to: CGSize(width: columns, height: rows)) else { return }
+        guard let data = scaled.dataProvider?.data else { return }
+        let ptr = CFDataGetBytePtr(data)
+
+        var newGrid: [String] = []
+        for y in 0..<rows {
+            for x in 0..<columns {
+                let offset = (y * columns + x) * 4
+                let r = Int(ptr[offset])
+                let g = Int(ptr[offset + 1])
+                let b = Int(ptr[offset + 2])
+                newGrid.append(closestEmoji(r: r, g: g, b: b))
+            }
+        }
+        DispatchQueue.main.async {
+            self.emojiGrid = newGrid
+        }
+    }
+
+    private let palette: [(emoji: String, r: Int, g: Int, b: Int)] = [
+        ("⬛️", 0, 0, 0),
+        ("⬜️", 255, 255, 255),
+        ("🟥", 255, 0, 0),
+        ("🟧", 255, 165, 0),
+        ("🟨", 255, 255, 0),
+        ("🟩", 0, 128, 0),
+        ("🟦", 0, 0, 255),
+        ("🟪", 128, 0, 128),
+        ("🟫", 165, 42, 42)
+    ]
+
+    private func closestEmoji(r: Int, g: Int, b: Int) -> String {
+        var best = palette[0]
+        var bestDistance = Int.max
+        for candidate in palette {
+            let dr = r - candidate.r
+            let dg = g - candidate.g
+            let db = b - candidate.b
+            let distance = dr * dr + dg * dg + db * db
+            if distance < bestDistance {
+                bestDistance = distance
+                best = candidate
+            }
+        }
+        return best.emoji
+    }
+}
+
+private extension CGImage {
+    func scaled(to size: CGSize) -> CGImage? {
+        guard let colorSpace = self.colorSpace else { return nil }
+        let width = Int(size.width)
+        let height = Int(size.height)
+        guard let context = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: width * 4, space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+        context.interpolationQuality = .none
+        context.draw(self, in: CGRect(origin: .zero, size: size))
+        return context.makeImage()
+    }
+}

--- a/EmojiCam/ContentView.swift
+++ b/EmojiCam/ContentView.swift
@@ -1,21 +1,26 @@
-//
-//  ContentView.swift
-//  EmojiCam
-//
-//  Created by Lian on 06.09.25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var viewModel = CameraEmojiViewModel()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        GeometryReader { geometry in
+            let cellWidth = geometry.size.width / CGFloat(viewModel.columns)
+            let cellHeight = geometry.size.height / CGFloat(viewModel.rows)
+            let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: viewModel.columns)
+
+            LazyVGrid(columns: columns, spacing: 0) {
+                ForEach(0..<viewModel.emojiGrid.count, id: \.self) { index in
+                    Text(viewModel.emojiGrid[index])
+                        .frame(width: cellWidth, height: cellHeight)
+                }
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+            .background(Color.black)
+            .onAppear { viewModel.startSession() }
+            .onDisappear { viewModel.stopSession() }
         }
-        .padding()
+        .ignoresSafeArea()
     }
 }
 


### PR DESCRIPTION
## Summary
- render the selfie camera feed as an emoji mosaic
- show a full-screen emoji grid driven by the camera
- describe camera usage in build settings

## Testing
- `xcodebuild -scheme EmojiCam -project EmojiCam.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1ddebd2c832086ef95e96570a750