### PR TITLE
Use compatible AVCaptureConnection orientation handling

### DIFF
--- a/EmojiCam/CameraEmojiViewModel.swift
+++ b/EmojiCam/CameraEmojiViewModel.swift
@@ -47,9 +47,7 @@ class CameraEmojiViewModel: NSObject, ObservableObject, AVCaptureVideoDataOutput
         guard session.canAddOutput(output) else { return }
         session.addOutput(output)
         if let connection = output.connection(with: .video) {
-            if #available(iOS 17.0, *) {
-                try? connection.setVideoRotationAngle(90)
-            } else {
+            if connection.isVideoOrientationSupported {
                 connection.videoOrientation = .portrait
             }
         }


### PR DESCRIPTION
## Summary
- avoid `setVideoRotationAngle` which isn't available before iOS 17
- set `videoOrientation` when supported to keep preview upright

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bc20822768832087921c2506286011