### PR TITLE
Replace deprecated video orientation APIs

### DIFF
--- a/EmojiCam/CameraEmojiViewModel.swift
+++ b/EmojiCam/CameraEmojiViewModel.swift
@@ -47,8 +47,9 @@ class CameraEmojiViewModel: NSObject, ObservableObject, AVCaptureVideoDataOutput
         guard session.canAddOutput(output) else { return }
         session.addOutput(output)
         if let connection = output.connection(with: .video) {
-            if connection.isVideoOrientationSupported {
-                connection.videoOrientation = .portrait
+            let portraitAngle: CGFloat = 90
+            if connection.isVideoRotationAngleSupported(portraitAngle) {
+                connection.videoRotationAngle = portraitAngle
             }
         }
         session.commitConfiguration()


### PR DESCRIPTION
## Summary
- use `videoRotationAngle` instead of deprecated video orientation properties

## Testing
- `swiftc EmojiCam/CameraEmojiViewModel.swift -o /tmp/test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68bc21d5626c8320a12cf49ad974d6da