### PR TITLE
Improve emoji grid proportions and color analysis

### DIFF
--- a/EmojiCam/ContentView.swift
+++ b/EmojiCam/ContentView.swift
@@ -5,17 +5,20 @@ struct ContentView: View {
 
     var body: some View {
         GeometryReader { geometry in
-            let cellWidth = geometry.size.width / CGFloat(viewModel.columns)
-            let cellHeight = geometry.size.height / CGFloat(viewModel.rows)
-            let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: viewModel.columns)
+            let cellSize = min(geometry.size.width / CGFloat(viewModel.columns),
+                               geometry.size.height / CGFloat(viewModel.rows))
+            let columns = Array(repeating: GridItem(.fixed(cellSize), spacing: 0), count: viewModel.columns)
 
             LazyVGrid(columns: columns, spacing: 0) {
                 ForEach(0..<viewModel.emojiGrid.count, id: \.self) { index in
                     Text(viewModel.emojiGrid[index])
-                        .frame(width: cellWidth, height: cellHeight)
+                        .frame(width: cellSize, height: cellSize)
+                        .font(.system(size: cellSize))
                 }
             }
-            .frame(width: geometry.size.width, height: geometry.size.height)
+            .frame(width: cellSize * CGFloat(viewModel.columns),
+                   height: cellSize * CGFloat(viewModel.rows))
+            .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
             .background(Color.black)
             .onAppear { viewModel.startSession() }
             .onDisappear { viewModel.stopSession() }


### PR DESCRIPTION
## Summary
- prevent emoji grid and camera input from stretching
- disable front camera mirroring
- average pixel colors to better match emojis

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bc24958e8883208542ebf49460c660